### PR TITLE
Explicitly reference content-type and content-encoding in the proposal introduction.

### DIFF
--- a/draft-polli-resource-digests-http.md
+++ b/draft-polli-resource-digests-http.md
@@ -144,10 +144,10 @@ Changes are semantically compatible with existing implementations
 and better cover both the request and response cases.
 
 Being calculated on the selected representation, the
-Digest is tied to the Content-Encoding. 
+`Digest` value is tied to the `Content-Encoding` and `Content-Type` header fields:
+a given resource has thus multiple possible digests values.
 
-A given resource has thus multiple possible digests values.
-To allow both parties to exchange a Digest of a representation 
+To allow the exchange of a representation digest 
 with [no content codings](https://tools.ietf.org/html/rfc7231#section-3.1.2.1)
 two more algorithms are added (id-sha-256 and id-sha-512).
 

--- a/draft-polli-resource-digests-http.md
+++ b/draft-polli-resource-digests-http.md
@@ -143,9 +143,10 @@ or conveys a partial representation of a resource (eg. Range Requests).
 Changes are semantically compatible with existing implementations 
 and better cover both the request and response cases.
 
-Being calculated on the selected representation, the
-`Digest` value is tied to the `Content-Encoding` and `Content-Type` header fields:
-a given resource has thus multiple possible digests values.
+The value of `Digest` is calculated on selected representation, 
+which is tied to the value contained in any `Content-Encoding` or `Content-Type` 
+header fields.
+Therefore, a given resource may have multiple different digest values.
 
 To allow the exchange of a representation digest 
 with [no content codings](https://tools.ietf.org/html/rfc7231#section-3.1.2.1)


### PR DESCRIPTION
## This PR

Explicitly reference content-type and content-encoding in the proposal introduction.

@LPardue does it sound better? Actuallly the method's too impacts on
resource representation (eg. HEAD vs GET). Should we state it here too?