### PR TITLE
Added IANA considerations for obsoleted algorithms. #16

### DIFF
--- a/draft-polli-resource-digests-http.md
+++ b/draft-polli-resource-digests-http.md
@@ -317,7 +317,7 @@ Response:
     The output of this algorithm is encoded using the
     base64 encoding  [RFC4648].
     The MD5 algorithm is NOT RECOMMENDED as it's now vulnerable
-    to collision attacks [CMU-836068]
+    to collision attacks [CMU-836068].
 
     Reference: [RFC1321], [RFC4648], this document.
 
@@ -327,7 +327,7 @@ Response:
   : The SHA-1 algorithm [FIPS180-1].  The output of this
     algorithm is encoded using the base64 encoding  [RFC4648].
     The SHA algorithm is NOT RECOMMENDED as it's now vulnerable
-    to collision attacks
+    to collision attacks [IACR-2019-459].
 
     Reference: [FIPS-180-3], [RFC4648], this document.
 
@@ -486,10 +486,10 @@ this header has been obsoleted by [RFC7231]
 # Broken cryptographic algorithms are NOT RECOMMENDED
 
 The MD5 algorithm is NOT RECOMMENDED as it's now vulnerable
-to collision attacks [CMU-836068]
+to collision attacks [CMU-836068].
 
-The SHA-1 algorithm is NOT RECOMMENDED as it's now vulnerable
-to collision attacks [IACR-2019-459]
+The SHA algorithm is NOT RECOMMENDED as it's now vulnerable
+to collision attacks [IACR-2019-459].
 
 # Examples
 
@@ -643,13 +643,23 @@ Response:
 Cryptographic algorithms are supposed to provide a proof of integrity
 usable eg. in signatures.
 
-To discourage mistakes, this spec explicits that broken-cryptographic algorithms
-like `MD5` and `SHA-1` are NOT RECOMMENDED.
+To discourage mistakes, broken-cryptographic algorithms
+like `MD5` and `SHA-1` are now NOT RECOMMENDED.
 
-Non cryptographic digest-algoritms (eg. `UNIXsum`)
-are retained for other use cases, like end-to-end integrity over multiple hops:
-while each hop is protected by TLS, the contents could get somehow malformed
-by buggy manipulation, buggy compressor, etc.
+## Digest for end-to-end integrity
+
+`Digest` alone does not provide end-to-end integrity
+of HTTP messages over multiple hops, as it just covers
+the representation-data and not the representation metadata.
+
+Besides, it allows to protect representation data from
+buggy manipulation, buggy compression, etc.
+
+Moreover identity digest algorithms (eg. ID-SHA-256 and ID-SHA-512)
+allow piecing together a resource from different sources
+(e.g. different servers that perhaps apply different content codings)
+enabling the user-agent to detect that the application-layer tasks completed properly,
+before handing off to say the HTML parser, video player etc.
 
 Even a simple mechanism for end-to-end validation is thus valuable.
 
@@ -663,8 +673,10 @@ signing only the `Digest` header, without all the representation metatada (eg.
 the values of `Content-Type` and `Content-Encoding`) may expose the communication
 to tampering.
 
-A `Digest` header using NOT RECOMMENDED {digest-algorithms} MUST NOT be used in signatures.
+`Digest` SHOULD always be used over a connection which provides
+integrity at transport layer that protects HTTP headers.
 
+A `Digest` header using NOT RECOMMENDED {digest-algorithms} MUST NOT be used in signatures.
 
 ## Message Truncation
 
@@ -782,6 +794,11 @@ Author/Change controller:  IETF
 Specification document(s):  {{digest-header}} of this document
 
 --- back
+
+# Change Log
+
+RFC EDITOR PLEASE DELETE THIS SECTION.
+
 
 # Acknowledgements
 

--- a/draft-polli-resource-digests-http.md
+++ b/draft-polli-resource-digests-http.md
@@ -458,7 +458,7 @@ knowing that the recipient will ignore it.
 This RFC deprecates the negotiation of Content-MD5 as
 this header has been obsoleted by [RFC7231]
 
-# Deprecate broken cryptographic algorithms
+# Broken cryptographic algorithms are NOT RECOMMENDED
 
 The MD5 algorithm is NOT RECOMMENDED as it's now vulnerable
 to collision attacks [CMU-836068]
@@ -613,13 +613,13 @@ Response:
 
 # Security Considerations
 
-## Deprecate broken cryptographic algorithms
+## Broken cryptographic algorithms
 
 Cryptographic algorithms are supposed to provide a proof of integrity
 usable eg. in signatures.
 
-To discourage mistakes, this spec deprecates broken-cryptographic algorithms
-like `MD5` and `SHA-1`.
+To discourage mistakes, this spec explicits that broken-cryptographic algorithms
+like `MD5` and `SHA-1` are NOT RECOMMENDED.
 
 Non cryptographic digest-algoritms (eg. `UNIXsum`)
 are retained for other use cases, like end-to-end integrity over multiple hops:
@@ -633,10 +633,12 @@ Even a simple mechanism for end-to-end validation is thus valuable.
 Digital signatures are widely used together with checksums to provide
 the certain identification of the origin of a message [NIST800-32].
 
-It's important to note that, being the Digest header an hash of a resource representation,
+It's important to note that, being the `Digest` header an hash of a resource representation,
 signing only the `Digest` header, without all the representation metatada (eg.
 the values of `Content-Type` and `Content-Encoding`) may expose the communication
 to tampering.
+
+A `Digest` header using NOT RECOMMENDED {digest-algorithms} MUST NOT be used in signatures.
 
 
 ## Message Truncation

--- a/draft-polli-resource-digests-http.md
+++ b/draft-polli-resource-digests-http.md
@@ -74,6 +74,13 @@ normative:
       ins: Carnagie Mellon University, Software Engineering Institute
     date: 2008-12-31
     target: https://www.kb.cert.org/vuls/id/836068/
+  IACR-2019-459:
+    title: From Collisions to Chosen-Prefix Collisions Application to Full SHA-1
+    author:
+      name: Leurent, G, Peyrin, T
+      ins: Inria, France; Nanyang Technological University, Singapore; Temasek Laboratories, Singapore
+    date: 2019-05-06
+    target: https://eprint.iacr.org/2019/459.pdf
 
 informative:
   RFC2818:
@@ -447,11 +454,17 @@ knowing that the recipient will ignore it.
 ...
 
 # Deprecate Negotiation of Content-MD5
+
 This RFC deprecates the negotiation of Content-MD5 as
 this header has been obsoleted by [RFC7231]
 
+# Deprecate broken cryptographic algorithms
+
 The MD5 algorithm is NOT RECOMMENDED as it's now vulnerable
 to collision attacks [CMU-836068]
+
+The SHA-1 algorithm is NOT RECOMMENDED as it's now vulnerable
+to collision attacks [IACR-2019-459]
 
 # Examples
 
@@ -599,6 +612,18 @@ Response:
 
 
 # Security Considerations
+
+## Deprecate broken cryptographic algorithms
+
+Cryptographic algorithms are supposed to provide a proof of integrity
+usable eg. in signatures.
+
+To discourage mistakes, this spec deprecates broken-cryptographic algorithms
+like `MD5` and `SHA-1`.
+
+It is reasonable to retain non cryptographic digest-algoritms
+like `UNIXsum` even if they are no stronger than
+the transport-layer integrity protection that guards each hop.
 
 ## Usage in signatures
 

--- a/draft-polli-resource-digests-http.md
+++ b/draft-polli-resource-digests-http.md
@@ -677,7 +677,7 @@ to tampering.
 `Digest` SHOULD always be used over a connection which provides
 integrity at transport layer that protects HTTP headers.
 
-A `Digest` header using NOT RECOMMENDED {digest-algorithms} MUST NOT be used in signatures.
+A `Digest` header using NOT RECOMMENDED {digest-algorithms} SHOULD NOT be used in signatures.
 
 ## Message Truncation
 

--- a/draft-polli-resource-digests-http.md
+++ b/draft-polli-resource-digests-http.md
@@ -640,11 +640,12 @@ Response:
 
 ## Broken cryptographic algorithms
 
-Cryptographic algorithms are supposed to provide a proof of integrity
-usable eg. in signatures.
+Cryptogrphic alorithms are intended to provide a proof of integrity
+suited towards cryptographic constructions such as signatures.
 
-To discourage mistakes, broken-cryptographic algorithms
-like `MD5` and `SHA-1` are now NOT RECOMMENDED.
+However, these rely on collision-resistance for their security proofs [CMU-836068].
+The MD5 and SHA-1 algorithms are vulnerable to collisions attacks and 
+they are NOT RECOMMENDED.
 
 ## Digest for end-to-end integrity
 

--- a/draft-polli-resource-digests-http.md
+++ b/draft-polli-resource-digests-http.md
@@ -621,9 +621,12 @@ usable eg. in signatures.
 To discourage mistakes, this spec deprecates broken-cryptographic algorithms
 like `MD5` and `SHA-1`.
 
-It is reasonable to retain non cryptographic digest-algoritms
-like `UNIXsum` even if they are no stronger than
-the transport-layer integrity protection that guards each hop.
+Non cryptographic digest-algoritms (eg. `UNIXsum`)
+are retained for other use cases, like end-to-end integrity over multiple hops:
+while each hop is protected by TLS, the contents could get somehow malformed
+by buggy manipulation, buggy compressor, etc.
+
+Even a simple mechanism for end-to-end validation is thus valuable.
 
 ## Usage in signatures
 

--- a/draft-polli-resource-digests-http.md
+++ b/draft-polli-resource-digests-http.md
@@ -295,20 +295,36 @@ Response:
 
     Reference: [FIPS180-3], [RFC4648], this document.
 
+    Status: standard
+
   SHA-512:
   : The SHA-512 algorithm [FIPS180-3].  The output of
     this algorithm is encoded using the base64 encoding [RFC4648].
 
     Reference: [FIPS180-3], [RFC4648], this document.
 
+    Status: standard
+
   MD5:
   : The MD5 algorithm, as specified in [RFC1321].
     The output of this algorithm is encoded using the
     base64 encoding  [RFC4648].
+    The MD5 algorithm is NOT RECOMMENDED as it's now vulnerable
+    to collision attacks [CMU-836068]
+
+    Reference: [RFC1321], [RFC4648], this document.
+
+    Status: obsoleted
 
   SHA:
   : The SHA-1 algorithm [FIPS180-1].  The output of this
     algorithm is encoded using the base64 encoding  [RFC4648].
+    The SHA algorithm is NOT RECOMMENDED as it's now vulnerable
+    to collision attacks
+
+    Reference: [FIPS-180-3], [RFC4648], this document.
+
+    Status: obsoleted
 
   UNIXsum:
   : The algorithm computed by the UNIX "sum" command,
@@ -333,9 +349,18 @@ the following additional algorithms are defined:
    : The sha-512 digest of the representation-data of the resource when no
      content coding is applied (eg. `Content-Encoding: identity`)
 
+     Reference: [FIPS180-3], [RFC4648], this document.
+
+     Status: standard
+
+
    ID-SHA-256:
    : The sha-256 digest of the representation-data of the resource when no
      content coding is applied (eg. `Content-Encoding: identity`)
+
+     Reference: [FIPS180-3], [RFC4648], this document.
+
+     Status: standard
 
    If other digest-algorithm values are defined, the associated encoding
    MUST either be represented as a quoted string, or MUST NOT include
@@ -450,8 +475,6 @@ knowing that the recipient will ignore it.
 This RFC deprecates the negotiation of Content-MD5 as
 this header has been obsoleted by [RFC7231]
 
-The MD5 algorithm is NOT RECOMMENDED as it's now vulnerable
-to collision attacks [CMU-836068]
 
 # Examples
 
@@ -621,6 +644,49 @@ to tampering.
 
 # IANA Considerations
 
+## Establish the HTTP Digest Algorithm Values
+
+This memo sets this spec to be the establishing
+document for the [HTTP Digest
+Algorithm
+Values](https://www.iana.org/assignments/http-dig-alg/http-dig-alg.xhtml)
+
+## The "status" field in the HTTP Digest Algorithm Values
+
+This memo adds the field "Status" to the [HTTP Digest
+Algorithm
+Values](https://www.iana.org/assignments/http-dig-alg/http-dig-alg.xhtml)
+registry. The allowed values for the "Status" fields are described below.
+
+   Status
+   :  Specify "standard", "experimental", "historic",
+      "obsoleted", or "deprecated" according to the type
+      and status of the primary document in which the algorithm
+      is defined.
+
+## Obsolete "MD5" Digest Algorithm {#iana-MD5}
+
+This memo updates the "MD5" digest algorithm in the [HTTP Digest
+Algorithm
+Values](https://www.iana.org/assignments/http-dig-alg/http-dig-alg.xhtml)
+registry:
+
+* Digest Algorithm: MD5
+* Description: As specified in {{algorithms}}.
+* Status: As specified in {{algorithms}}.
+
+
+## Obsolete "SHA" Digest Algorithm {#iana-SHA}
+
+This memo updates the "SHA" digest algorithm in the [HTTP Digest
+Algorithm
+Values](https://www.iana.org/assignments/http-dig-alg/http-dig-alg.xhtml)
+registry:
+
+* Digest Algorithm: SHA
+* Description: As specified in {{algorithms}}.
+* Status: As specified in {{algorithms}}.
+
 ## The "ID-SHA-256" Digest Algorithm {#iana-ID-SHA-256}
 
 This memo registers the "ID-SHA-256" digest algorithm in the [HTTP Digest
@@ -630,6 +696,7 @@ registry:
 
 * Digest Algorithm: ID-SHA-256
 * Description: As specified in {{algorithms}}.
+* Status: As specified in {{algorithms}}.
 
 ## The "ID-SHA-512" Digest Algorithm {#iana-ID-SHA-512}
 
@@ -640,6 +707,17 @@ registry:
 
 * Digest Algorithm: ID-SHA-512
 * Description: As specified in {{algorithms}}.
+* Status: As specified in {{algorithms}}.
+
+## Changes compared to RFC5843
+
+The status has been updated to "obsoleted" for both "SHA" and "MD5",
+and their descriptions states that those algorithms are NOT RECOMMENDED.
+
+The status for all other algorithms have been updated to "standard".
+
+The "ID-SHA-256" and "ID-SHA-512" algorithms have been added to
+the registry.
 
 ## Want-Digest Header Field Registration
 
@@ -705,13 +783,13 @@ the MICE Content Encoding.
    - a `200 OK` response to a PATCH request would contain the digest of the patched item, and the etag of the new object.
      This behavior - tighly coupled to the application logic - gives the client low probability of guessing the actual
      outcome of this operation (eg. concurrent changes, ...)
-     
+
 4. Why remove references to delta-encoding?
 
    Unnecessary for a correct implementation of this spec. The revised spec can be nicely adapted
    to "delta encoding", but all the references here to delta encoding don't add anything to this RFC.
    Another job would be to refresh delta encoding.
-   
+
 5. Why remove references to Digest Authentication?
 
    This RFC seems to me completely unrelated to Digest Authentication but for the word "Digest".


### PR DESCRIPTION
## This PR

- specifies MD5 and SHA1 collisions
- add `Status` to IANA Digest Algorithms
- Set `obsoleted` status on MD5 and SHA1