### PR TITLE
Fix: #22. Use base64 to represent binary payloads

### DIFF
--- a/draft-polli-resource-digests-http.md
+++ b/draft-polli-resource-digests-http.md
@@ -586,7 +586,7 @@ Response:
   Content-Encoding: br
   Digest: sha-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=
 
-  b'\x8b\x08\x80{"hello": "world"}\x03'
+  iwiAeyJoZWxsbyI6ICJ3b3JsZCJ9Aw==
 
 ~~~
 


### PR DESCRIPTION
## This PR

Represents binary payloads with base64